### PR TITLE
set C++ version to 11 (boost:shared_ptr is now std::shared_ptr, older…

### DIFF
--- a/youbot_arm_kinematics_moveit/CMakeLists.txt
+++ b/youbot_arm_kinematics_moveit/CMakeLists.txt
@@ -1,4 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
+set (CMAKE_CXX_STANDARD 11)
+
 project(youbot_arm_kinematics_moveit)
 
 find_package(catkin REQUIRED


### PR DESCRIPTION
set C++ version to 11 (boost:shared_ptr is now std::shared_ptr, older versions require to use boost::shared_ptr